### PR TITLE
Add in babel eslint parser

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "eslint-config-standard": "^4.4.0",
     "eslint-plugin-react": "^3.14.0",
     "eslint-plugin-standard": "^1.3.1",
+    "babel-eslint": "^5.0.0",
     "hound-javascript": "0.0.2",
     "node-resque": "^1.3.0",
     "redis": "^2.1.0",


### PR DESCRIPTION
Proposing adding the `babel-eslint` parser so that folks using Babel to transpile their code can also use the ESLint within the HoundCI service. The ESLint parser is configurable:

http://eslint.org/docs/user-guide/configuring#specifying-parser

Without this node module, users using `parser: 'babel-eslint'` would not work because it's not installed by default. I think this change should allow things to work...Thanks!

https://twitter.com/beaktor/status/705104381041991680
https://twitter.com/beaktor/status/705104669601767424