### PR TITLE
Upgrade eslint-config-littlebits

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "dependencies": {
     "eslint": "^1.6.0",
     "eslint-config-airbnb": "^3.1.0",
-    "eslint-config-littlebits": "^0.3.0",
+    "eslint-config-littlebits": "^0.5.0",
     "eslint-config-semistandard": "^5.0.0",
     "eslint-config-standard": "^4.4.0",
     "eslint-plugin-react": "^3.14.0",


### PR DESCRIPTION
This change updates the [eslint-config-littlebits](https://github.com/littlebits/code-standards-js) package to the latest version, which is compatible with eslint 2.0

This should unblock houndci/eslint#18