### PR TITLE
fix typo in job name

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,7 +14,7 @@ var worker = new Resque.multiWorker({
   connection: { redis: redis },
   queues: ["eslint_review"],
 }, {
-  "EslintReviewJob": function(payload, callback) {
+  "EsLintReviewJob": function(payload, callback) {
     linter.lint(payload).finally(callback);
   }
 });


### PR DESCRIPTION
the error in the name leads to a job failure with this error message
No job defined for class 'EsLintReviewJob'