### PR TITLE
Ensure known plugins are parsed from config

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -43,11 +43,10 @@ Config.prototype.requirePlugin = function(pluginName) {
   var pluginNamespace = plugins.getNamespace(pluginName);
   var nameWithoutNamespace = plugins.removeNamespace(pluginName);
   var nameWithoutPrefix = plugins.removePrefix(nameWithoutNamespace);
+  var pluginPrefix = "eslint-plugin-";
 
   if (whitelist.indexOf(nameWithoutPrefix) > -1) {
-    var plugin = require(
-      pluginNamespace + plugins.PLUGIN_NAME_PREFIX + nameWithoutPrefix
-    );
+    var plugin = require(pluginNamespace + pluginPrefix + nameWithoutPrefix);
     // if this plugin has rules, import them
     if (plugin.rules) {
       rules.import(plugin.rules, nameWithoutPrefix);

--- a/tests/config-test.js
+++ b/tests/config-test.js
@@ -5,7 +5,9 @@ var Config = require("../lib/config");
 QUnit.module("Config");
 
 test("Parsing an ESLint config file", function() {
-  var config = new Config("{ \"rules\": { \"semi\": 2, }, }");
+  var config = new Config(
+    "{\"plugins\": [\"react\"], \"rules\": { \"semi\": 2, }, }"
+  );
 
   deepEqual(
     config.parse(),
@@ -14,6 +16,7 @@ test("Parsing an ESLint config file", function() {
       env: {},
       rules: { semi: 2 },
       parserOptions: {},
+      plugins: ['react'],
     }
   );
 });


### PR DESCRIPTION
ESLint changed the access of `PLUGIN_NAME_PREFIX` constant -- it is no
longer exported. It is a well-know prefix, so we can just hard code it
on our side.

Since we didn't test for plugins in the config, we didn't catch this
issue. A test has been added as part of this commit.