### PR TITLE
Add other eslint-plugins-* to the whitelist

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -7,6 +7,9 @@ var plugins = require("eslint/lib/config/plugins");
 var whitelist = [
   "react",
   "standard",
+  "import",
+  "jsx-a11y",
+  "promise",
 ];
 
 function Config(rawConfig) {


### PR DESCRIPTION
**Fixes:** https://github.com/houndci/eslint/issues/32
**May also resolve:** https://github.com/houndci/eslint/issues/34

## Context
In the ["Upgrade ESLint to 2.8.0" Pull Request][0], a lot of `eslint-plugins-*` were added to the package.json (as a result of `eslint-config-airbnb` `dependencies`), but were not added to the whitelist.

[Looking at the source code of your *config.js*][1], we also need to add in those plugin names to [the local whitelist][2] in order for the all those plugins' rules to be imported as well.


## The Problem
As an example, this is currently what hound outputs without the `eslint-plugin-import` rules, despite linters being fine on local dev machines:

![screen shot 2016-06-17 at 10 28 39 am](https://cloud.githubusercontent.com/assets/5249615/16159233/68f90402-3476-11e6-945f-837304222142.png)



[0]: https://github.com/houndci/eslint/pull/25
[1]: https://github.com/houndci/eslint/blob/master/lib/config.js#L48
[2]: https://github.com/houndci/eslint/blob/master/lib/config.js#L7-L10

## This PR
+ Adds the following `eslint-plugin-*`s to the whitelist
  + `"import"`
  + `"jsx-a11y"`
  + `"promise"`